### PR TITLE
Change wording when modifying entries

### DIFF
--- a/src/fde.rs
+++ b/src/fde.rs
@@ -835,14 +835,14 @@ fn form_display_inner(form: &Form, user_input: &mut UserInput) -> Result<()> {
                 };
 
                 if editing {
-                    render_hotkey_help("Esc=Exit Entry");
+                    render_hotkey_help("Esc=Discard Changes");
                 } else {
                     render_hotkey_help("Esc=Exit");
                 }
                 if selected == !0 {
                     render_hotkey_help("");
                 } else if editing {
-                    render_hotkey_help("Enter=Complete Entry");
+                    render_hotkey_help("Enter=Save Changes");
                 } else {
                     render_hotkey_help("Enter=Select Entry");
                 }


### PR DESCRIPTION
Use more common "Save/Discard Changes" instead of "Complete/Exit Entry"
when modifying fields/lists.

Note: No distinction is made between saving the in-memory value vs
committing it to disk, so users may still get confused by it.