### PR TITLE
Disallow exiting the formset with Escape

### DIFF
--- a/src/fde.rs
+++ b/src/fde.rs
@@ -1021,7 +1021,7 @@ fn form_display_inner(form: &Form, user_input: &mut UserInput) -> Result<()> {
                         if editing {
                             editing = false;
                             break 'display;
-                        } else {
+                        } else if form.FormId != FRONT_PAGE_FORM_ID {
                             user_input.Action = 1 << 17;
                             break 'render;
                         }


### PR DESCRIPTION
This is the default behavior in edk2's DisplayEngineDxe [\[1\]](https://github.com/tianocore/edk2/blob/422da35375c6d95dae9d5c56530d255b672b1f59/MdeModulePkg/Universal/DisplayEngineDxe/FormDisplay.c#L3374), which we override with firmware-setup.