### PR TITLE
Use 0x7600 as front page form ID to avoid conflict with device manager

### DIFF
--- a/src/fde.rs
+++ b/src/fde.rs
@@ -291,7 +291,7 @@ pub struct Form {
     pub ErrorString: *const u16,
 }
 
-const FRONT_PAGE_FORM_ID: u16 = 0x1000;
+const FRONT_PAGE_FORM_ID: u16 = 0x7600;
 
 #[repr(C)]
 pub struct UserInput {


### PR DESCRIPTION
Required for https://github.com/system76/edk2/pull/13