### PR TITLE
Fix calculation of maximum number of form body elements

### DIFF
--- a/src/fde.rs
+++ b/src/fde.rs
@@ -791,6 +791,7 @@ fn form_display_inner(form: &Form, user_input: &mut UserInput) -> Result<()> {
                 .map(|e| (e.list, e.options.is_empty()))
                 .unwrap_or((false, false));
 
+            // Draw header
             if let Some(ref title) = title_opt {
                 // TODO: Do not render in drawing loop
                 let rendered = font.render(&title, title_font_size);
@@ -807,36 +808,6 @@ fn form_display_inner(form: &Form, user_input: &mut UserInput) -> Result<()> {
                 Color::rgb(0xac, 0xac, 0xac)
             );
             y += margin_tb * 2;
-
-            if element_start > 0 {
-                // Draw up arrow to indicate more items above
-                let arrow = font.render("↑", help_font_size);
-                draw_text_box(&mut display, (display_w - arrow.width()) as i32 - margin_lr, y, &arrow, false, false);
-            }
-
-            for i in element_start..(element_start + max_form_elements) {
-                if let Some(element) = elements.get(i) {
-                    let highlighted = i == selected;
-                    let h = {
-                        // TODO: Do not render in drawing loop
-                        let rendered = font.render(&element.prompt, font_size);
-                        draw_text_box(&mut display, margin_lr, y, &rendered, highlighted && ! editing, highlighted && ! editing);
-                        rendered.height() as i32
-                    };
-
-                    let x = display_w as i32 / 2;
-                    if element.list {
-                        y = draw_options_box(&mut display, x, y, element);
-                        y -= h + margin_tb;
-                    } else if let Some(option) = element.options.iter().find(|o| o.value == element.value) {
-                        draw_text_box(&mut display, x, y, &option.prompt, true, highlighted && editing);
-                    } else if element.editable {
-                        draw_value_box(&mut display, x, y, &element.value, highlighted && editing);
-                    }
-
-                    y += h + margin_tb;
-                }
-            }
 
             // Draw footer
             {
@@ -898,7 +869,6 @@ fn form_display_inner(form: &Form, user_input: &mut UserInput) -> Result<()> {
                     Color::rgb(0xac, 0xac, 0xac)
                 );
 
-
                 if let Some(element) = elements.get(selected) {
                     if !element.help.trim().is_empty() {
                         let rendered = font.render(&element.help, help_font_size);
@@ -915,6 +885,37 @@ fn form_display_inner(form: &Form, user_input: &mut UserInput) -> Result<()> {
                             Color::rgb(0xac, 0xac, 0xac)
                         );
                     }
+                }
+            }
+
+            // Draw body
+            if element_start > 0 {
+                // Draw up arrow to indicate more items above
+                let arrow = font.render("↑", help_font_size);
+                draw_text_box(&mut display, (display_w - arrow.width()) as i32 - margin_lr, y, &arrow, false, false);
+            }
+
+            for i in element_start..(element_start + max_form_elements) {
+                if let Some(element) = elements.get(i) {
+                    let highlighted = i == selected;
+                    let h = {
+                        // TODO: Do not render in drawing loop
+                        let rendered = font.render(&element.prompt, font_size);
+                        draw_text_box(&mut display, margin_lr, y, &rendered, highlighted && ! editing, highlighted && ! editing);
+                        rendered.height() as i32
+                    };
+
+                    let x = display_w as i32 / 2;
+                    if element.list {
+                        y = draw_options_box(&mut display, x, y, element);
+                        y -= h + margin_tb;
+                    } else if let Some(option) = element.options.iter().find(|o| o.value == element.value) {
+                        draw_text_box(&mut display, x, y, &option.prompt, true, highlighted && editing);
+                    } else if element.editable {
+                        draw_value_box(&mut display, x, y, &element.value, highlighted && editing);
+                    }
+
+                    y += h + margin_tb;
                 }
             }
 

--- a/src/fde.rs
+++ b/src/fde.rs
@@ -785,6 +785,7 @@ fn form_display_inner(form: &Form, user_input: &mut UserInput) -> Result<()> {
             };
 
             let mut y = margin_tb;
+            let mut bottom_y = display_h as i32;
 
             let (editing_list, editing_value) = elements.get(selected)
                 .map(|e| (e.list, e.options.is_empty()))
@@ -839,14 +840,12 @@ fn form_display_inner(form: &Form, user_input: &mut UserInput) -> Result<()> {
 
             // Draw footer
             {
-                y = display_h as i32;
-
                 let mut i = 0;
                 let mut render_hotkey_help = |help: &str| {
                     let rendered = font.render(help, help_font_size);
                     let x = match i % 3 {
                         0 => {
-                            y -= rendered.height() as i32 + margin_tb;
+                            bottom_y -= rendered.height() as i32 + margin_tb;
                             (display_w as i32) * 2 / 3 + margin_lr
                         },
                         1 =>  {
@@ -856,7 +855,7 @@ fn form_display_inner(form: &Form, user_input: &mut UserInput) -> Result<()> {
                             margin_lr
                         }
                     };
-                    draw_text_box(&mut display, x, y, &rendered, false, false);
+                    draw_text_box(&mut display, x, bottom_y, &rendered, false, false);
                     i += 1;
                 };
 
@@ -890,10 +889,10 @@ fn form_display_inner(form: &Form, user_input: &mut UserInput) -> Result<()> {
                     }
                 }
 
-                y -= margin_tb * 3 / 2;
+                bottom_y -= margin_tb * 3 / 2;
                 display.rect(
                     0,
-                    y,
+                    bottom_y,
                     display_w,
                     1,
                     Color::rgb(0xac, 0xac, 0xac)
@@ -904,13 +903,13 @@ fn form_display_inner(form: &Form, user_input: &mut UserInput) -> Result<()> {
                     if !element.help.trim().is_empty() {
                         let rendered = font.render(&element.help, help_font_size);
                         let x = (display_w as i32 - rendered.width() as i32) / 2;
-                        y -= rendered.height() as i32 + margin_tb;
-                        draw_text_box(&mut display, x, y, &rendered, false, false);
+                        bottom_y -= rendered.height() as i32 + margin_tb;
+                        draw_text_box(&mut display, x, bottom_y, &rendered, false, false);
 
-                        y -= margin_tb * 3 / 2;
+                        bottom_y -= margin_tb * 3 / 2;
                         display.rect(
                             0,
-                            y,
+                            bottom_y,
                             display_w,
                             1,
                             Color::rgb(0xac, 0xac, 0xac)
@@ -922,7 +921,7 @@ fn form_display_inner(form: &Form, user_input: &mut UserInput) -> Result<()> {
             if elements.len() > max_form_elements && element_start < elements.len() - max_form_elements {
                 // Draw down arrow to indicate more items below
                 let arrow = font.render("↓", help_font_size);
-                draw_text_box(&mut display, (display_w - arrow.width()) as i32 - margin_lr, y - arrow.height() as i32 - margin_tb * 2, &arrow, false, false);
+                draw_text_box(&mut display, (display_w - arrow.width()) as i32 - margin_lr, bottom_y - arrow.height() as i32 - margin_tb * 2, &arrow, false, false);
             }
 
             display.sync();

--- a/src/fde.rs
+++ b/src/fde.rs
@@ -431,10 +431,6 @@ fn form_display_inner(form: &Form, user_input: &mut UserInput) -> Result<()> {
     let help_font_size = (12 * scale) as f32;
     // } Style
 
-    // TODO: Better calculation of maximum number of elements that can be displayed
-    let form_body_height = display_h - title_font_size as u32 - help_font_size as u32 - margin_tb as u32 * 4 - padding_tb as u32 * 4;
-    let max_form_elements = (form_body_height / (font_size as u32 + margin_tb as u32 + padding_tb as u32)) as usize;
-
     'render: loop {
         let mut hotkey_helps = Vec::new();
         for hotkey in form.HotKeyListHead.iter() {
@@ -889,6 +885,8 @@ fn form_display_inner(form: &Form, user_input: &mut UserInput) -> Result<()> {
             }
 
             // Draw body
+            let max_form_elements = ((bottom_y - y) / (font_size as i32 + margin_tb)) as usize;
+
             if element_start > 0 {
                 // Draw up arrow to indicate more items above
                 let arrow = font.render("↑", help_font_size);


### PR DESCRIPTION
The height of the header, footer, and help blocks are fixed once rendered. The size of the form body will change with display resolution, if the footer will show 1 or 2 rows, and if the help block is shown (#11). Draw it last so we can calculate exactly how much space it will use.