### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/fde.rs
+++ b/src/fde.rs
@@ -573,12 +573,12 @@ fn form_display_inner(form: &Form, user_input: &mut UserInput) -> Result<()> {
             let draw_value_box = |display: &mut Display, x: i32, y: i32, value: &IfrTypeValueEnum, highlighted: bool| -> i32 {
                 //TODO: Do not format in drawing loop
                 let value_string = match value {
-                    IfrTypeValueEnum::U8(value) => format!("{}", value),
-                    IfrTypeValueEnum::U16(value) => format!("{}", value),
-                    IfrTypeValueEnum::U32(value) => format!("{}", value),
-                    IfrTypeValueEnum::U64(value) => format!("{}", value),
+                    IfrTypeValueEnum::U8(value) => format!("{value}"),
+                    IfrTypeValueEnum::U16(value) => format!("{value}"),
+                    IfrTypeValueEnum::U32(value) => format!("{value}"),
+                    IfrTypeValueEnum::U64(value) => format!("{value}"),
                     IfrTypeValueEnum::Bool(value) => return ui.draw_check_box(display, x, y, *value),
-                    other => format!("{:?}", other),
+                    other => format!("{other:?}"),
                 };
 
                 // TODO: Do not render in drawing loop
@@ -735,7 +735,7 @@ fn form_display_inner(form: &Form, user_input: &mut UserInput) -> Result<()> {
                     // TODO: Do not render in drawing loop
                     let mut h = 0;
                     for line in element.prompt.lines() {
-                        let rendered = ui.font.render(&line, font_size);
+                        let rendered = ui.font.render(line, font_size);
                         ui.draw_text_box(display, margin_lr, y + h, &rendered, highlighted && ! editing, highlighted && ! editing);
                         h += rendered.height() as i32;
                     }

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -64,11 +64,6 @@ impl Image {
         })
     }
 
-    /// Create a new empty image
-    pub fn default() -> Self {
-        Self::new(0, 0)
-    }
-
     /// Get a piece of the image
     pub fn roi(&self, x: u32, y: u32, w: u32, h: u32) -> ImageRoi {
         let x1 = cmp::min(x, self.width());
@@ -93,6 +88,13 @@ impl Image {
     /// Draw the image on a window
     pub fn draw<R: Renderer>(&self, renderer: &mut R, x: i32, y: i32) {
         renderer.image_legacy(x, y, self.w, self.h, &self.data);
+    }
+}
+
+impl Default for Image {
+    /// Create a new empty image
+    fn default() -> Self {
+        Self::new(0, 0)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(asm)]
 #![feature(core_intrinsics)]
 #![feature(prelude_import)]
 #![feature(try_trait_v2)]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,9 +6,9 @@ use std::uefi::status::{Error, Result};
 use crate::display::Display;
 use crate::image::{self, Image};
 
-static FONT_TTF: &'static [u8] = include_bytes!("../res/FiraSans-Regular.ttf");
-static CHECKBOX_CHECKED_BMP: &'static [u8] = include_bytes!("../res/checkbox_checked.bmp");
-static CHECKBOX_UNCHECKED_BMP: &'static [u8] = include_bytes!("../res/checkbox_unchecked.bmp");
+static FONT_TTF: &[u8] = include_bytes!("../res/FiraSans-Regular.ttf");
+static CHECKBOX_CHECKED_BMP: &[u8] = include_bytes!("../res/checkbox_checked.bmp");
+static CHECKBOX_UNCHECKED_BMP: &[u8] = include_bytes!("../res/checkbox_unchecked.bmp");
 
 static mut FONT: *const Font = ptr::null_mut();
 static mut CHECKBOX_CHECKED: *const Image = ptr::null_mut();


### PR DESCRIPTION
Fix the following lints:

- stable_features
- clippy::needless_borrow
- clippy::redundant_static_lifetimes
- clippy::should_implement_trait
- clippy::uninlined_format_args