### PR TITLE
Remove asm feature enable in src/main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@
 
 #![no_std]
 #![no_main]
-#![feature(asm)]
 #![feature(core_intrinsics)]
 #![feature(prelude_import)]
 #![feature(try_trait_v2)]


### PR DESCRIPTION
The 'asm' feature has been stable since 1.59.0 and no longer requires an attribute to enable it.