### PR TITLE
serial: Switch from `repr(packed)` to `repr(C)`

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -26,7 +26,7 @@ bitflags! {
 }
 
 #[allow(dead_code)]
-#[repr(packed)]
+#[repr(C)]
 pub struct SerialPort<T: Io> {
     /// Data register, read to receive, write to send
     data: T,
@@ -68,7 +68,6 @@ impl SerialPort<Mmio<u32>> {
 impl<T: Io> SerialPort<T>
     where T::Value: From<u8> + TryInto<u8>
 {
-    #[allow(unaligned_references)]
     pub unsafe fn init(&mut self) {
         //TODO: Cleanup
         self.int_en.write(0x00.into());
@@ -81,14 +80,12 @@ impl<T: Io> SerialPort<T>
         self.int_en.write(0x01.into());
     }
 
-    #[allow(unaligned_references)]
     unsafe fn line_sts(&self) -> LineStsFlags {
         LineStsFlags::from_bits_truncate(
             (self.line_sts.read() & 0xFF.into()).try_into().unwrap_or(0)
         )
     }
 
-    #[allow(unaligned_references)]
     pub unsafe fn receive(&mut self) -> Option<u8> {
         if self.line_sts().contains(LineStsFlags::INPUT_FULL) {
             Some(
@@ -99,7 +96,6 @@ impl<T: Io> SerialPort<T>
         }
     }
 
-    #[allow(unaligned_references)]
     pub unsafe fn send(&mut self, data: u8) {
         while ! self.line_sts().contains(LineStsFlags::OUTPUT_EMPTY) {}
         self.data.write(data.into());


### PR DESCRIPTION
Is this valid?

Need to address `unaligned_refrences` to update the toolchain.

```
warning: lint `unaligned_references` has been removed: converted into hard error, see issue #82523 <https://github.com/rust-lang/rust/issues/82523> for more information
```