### PR TITLE
cargo: Use sparse index protocol

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[registries.crates-io]
+protocol = "sparse"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
 


### PR DESCRIPTION
Enable the protocol by config until the toolchain can be updated (#36). Makes fetching deps much faster as it doesn't need to build the git index.