### PR TITLE
Remove use of build-std, build-std-features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,6 @@ $(BUILD)/efi.img: $(BUILD)/boot.efi
 $(BUILD)/boot.efi: Cargo.lock Cargo.toml res/* src/* src/*/*
 	mkdir -p $(BUILD)
 	cargo rustc \
-		-Z build-std=core,alloc \
-		-Z build-std-features=compiler-builtins-mem \
 		--target $(TARGET) \
 		--release \
 		-- \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "nightly-2023-01-21"
-components = ["rust-src"]
+targets = ["x86_64-unknown-uefi"]
+profile = "minimal"


### PR DESCRIPTION
x86_64-unknown-uefi is a tier 2 supported target [1] that provides core and alloc (with redox_uefi providing the allocator). Nightly compiler options for building them are not needed.

[1]: https://doc.rust-lang.org/1.78.0/rustc/platform-support/unknown-uefi.html