### PR TITLE
Update redox_uefi_std to 0.1.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,21 +13,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "coreboot-table"
@@ -42,23 +36,23 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libredox"
-version = "0.0.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags",
  "libc",
  "redox_syscall",
 ]
@@ -93,9 +87,9 @@ dependencies = [
 
 [[package]]
 name = "orbclient"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f0d54bde9774d3a51dcf281a5def240c71996bc6ca05d2c847ec8b2b216166"
+checksum = "ba0b26cec2e24f08ed8bb31519a9333140a6599b867dac464bb150bdb796fd43"
 dependencies = [
  "libredox",
 ]
@@ -143,33 +137,33 @@ checksum = "8eb516ad341a84372b5b15a5a35cf136ba901a639c8536f521b108253d7fce74"
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
 name = "redox_uefi"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dbb9124e850a6953efb6ea3957d84fc48930a6dfd844d963bc8516c16f24e5"
+checksum = "c5d69301333534a04b380995f5d9e604f46a7cbd8d8c62c996ee27447efdeba4"
 
 [[package]]
 name = "redox_uefi_alloc"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ac0164918610031fe226ba74125aa03239eb86516131b8ee1e85de31b7c445"
+checksum = "1df364cdf289d9df9201f147aeeb5e7387f29f0824bee2e41e960eb98eaf03f1"
 dependencies = [
  "redox_uefi",
 ]
 
 [[package]]
 name = "redox_uefi_std"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e07da7709f8d1edbabf81657cd360886539c5c4a18fc047ed774bc1d6b466a"
+checksum = "b81203f45b2e08804d80274a2951f1615828d9aa5629d3a5d267878c70feb96d"
 dependencies = [
  "redox_uefi",
  "redox_uefi_alloc",
@@ -204,7 +198,7 @@ dependencies = [
 [[package]]
 name = "system76_ectool"
 version = "0.3.8"
-source = "git+https://github.com/system76/ec.git#88c77aa1d322d2cca56038b396b31a96bc42fe59"
+source = "git+https://github.com/system76/ec.git#3d8204c3f40b4de1e3b94f2c1aaca5f29a80122e"
 dependencies = [
  "downcast-rs",
  "redox_hwio",
@@ -214,7 +208,7 @@ dependencies = [
 name = "system76_firmware_setup"
 version = "1.0.0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags",
  "coreboot-table",
  "memoffset",
  "orbclient",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ orbfont = { version = "0.1.12", default-features = false, features = ["no-std"] 
 plain = "0.2.3"
 redox_dmi = "0.1.6"
 redox_hwio = { version = "0.1.6", default-features = false }
-redox_uefi_std = "0.1.11"
+redox_uefi_std = "0.1.13"
 spin = "0.9.4"
 
 [dependencies.system76_ectool]

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use core::cell::Cell;
-use core::ops::Try;
 use orbclient::{Color, Mode, Renderer};
+use std::prelude::*;
 use std::proto::Protocol;
 use std::uefi::graphics::{GraphicsOutput, GraphicsBltOp, GraphicsBltPixel};
-use std::uefi::guid::{Guid, GRAPHICS_OUTPUT_PROTOCOL_GUID};
+use std::uefi::guid::GRAPHICS_OUTPUT_PROTOCOL_GUID;
 
 pub struct Output(pub &'static mut GraphicsOutput);
 
@@ -53,7 +53,7 @@ impl Display {
             h as usize,
             0
         );
-        status.branch().is_continue()
+        status.is_success()
     }
 }
 

--- a/src/dump_hii.rs
+++ b/src/dump_hii.rs
@@ -4,11 +4,11 @@ use hwio::{Io, Pio};
 use std::{char, mem, ptr, str};
 use std::ops::Try;
 use std::proto::Protocol;
+use std::prelude::*;
 use std::uefi::hii::database::HiiHandle;
 use std::uefi::hii::ifr::{IfrOpCode, IfrOpHeader, IfrForm, IfrAction};
 use std::uefi::hii::package::{HiiPackageHeader, HiiPackageKind, HiiPackageListHeader, HiiStringPackageHeader};
 use std::uefi::hii::sibt::{SibtHeader, SibtKind, SibtEnd, SibtSkip2, SibtStringUcs2, SibtStringsUcs2};
-use std::uefi::status::{Error, Result};
 
 use crate::hii;
 

--- a/src/hii.rs
+++ b/src/hii.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use std::proto::Protocol;
+use std::prelude::*;
 use std::uefi::hii::database::HiiDatabase;
-use std::uefi::guid::{Guid, HII_DATABASE_GUID};
+use std::uefi::guid::HII_DATABASE_GUID;
 
 pub struct Database(pub &'static mut HiiDatabase);
 

--- a/src/image/bmp.rs
+++ b/src/image/bmp.rs
@@ -2,7 +2,9 @@
 
 use super::Image;
 
-pub fn parse(file_data: &[u8]) -> Result<Image, String> {
+use std::prelude::*;
+
+pub fn parse(file_data: &[u8]) -> core::result::Result<Image, String> {
     use orbclient::Color;
 
     let get = |i: usize| -> u8 {

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -2,7 +2,9 @@
 
 use core::cell::Cell;
 use core::cmp;
-use core::prelude::v1::derive;
+use core::default::Default;
+
+use std::prelude::*;
 
 use orbclient::{Color, Mode, Renderer};
 
@@ -51,7 +53,7 @@ impl Image {
     }
 
     /// Create a new image from a boxed slice of colors
-    pub fn from_data(width: u32, height: u32, data: Box<[Color]>) -> Result<Self, String> {
+    pub fn from_data(width: u32, height: u32, data: Box<[Color]>) -> core::result::Result<Self, String> {
         if (width * height) as usize != data.len() {
             return Err("not enough or too much data given compared to width and height".to_string())
         }

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use core::char;
-use core::prelude::v1::derive;
-use std::uefi::status::Result;
+use std::prelude::*;
 use std::uefi::text::TextInputKey;
 
 #[derive(Debug)]
@@ -79,7 +78,7 @@ pub fn raw_key(wait: bool) -> Result<TextInputKey> {
 
     if wait {
         let mut index = 0;
-        (uefi.BootServices.WaitForEvent)(1, &uefi.ConsoleIn.WaitForKey, &mut index)?;
+        Result::from((uefi.BootServices.WaitForEvent)(1, &uefi.ConsoleIn.WaitForKey, &mut index))?;
     }
 
     let mut key = TextInputKey {
@@ -87,7 +86,7 @@ pub fn raw_key(wait: bool) -> Result<TextInputKey> {
         UnicodeChar: 0
     };
 
-    (uefi.ConsoleIn.ReadKeyStroke)(uefi.ConsoleIn, &mut key)?;
+    Result::from((uefi.ConsoleIn.ReadKeyStroke)(uefi.ConsoleIn, &mut key))?;
 
     Ok(key)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,25 +2,16 @@
 
 #![no_std]
 #![no_main]
-#![feature(core_intrinsics)]
-#![feature(prelude_import)]
-#![feature(try_trait_v2)]
-#![feature(control_flow_enum)]
 #![allow(non_snake_case)]
 
-#[macro_use]
-extern crate bitflags;
 #[macro_use]
 extern crate memoffset;
 #[macro_use]
 extern crate uefi_std as std;
 
-#[allow(unused_imports)]
-#[prelude_import]
 use std::prelude::*;
 
 use core::ptr;
-use std::uefi::status::Status;
 
 #[macro_use]
 mod debug;

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,11 +1,6 @@
-use std::{
-    proto::Protocol,
-    ptr,
-};
-use std::uefi::{
-    guid::Guid,
-    status::{Result, Status},
-};
+use core::ptr;
+use std::proto::Protocol;
+use std::prelude::*;
 
 pub const RNG_PROTOCOL_GUID: Guid = Guid(0x3152bca5, 0xeade, 0x433d, [0x86, 0x2e, 0xc0, 0x1c, 0xdc, 0x29, 0x1f, 0x44]);
 
@@ -13,12 +8,12 @@ pub struct Rng(pub &'static mut RngProtocol);
 
 impl Rng {
     pub fn read(&self, buf: &mut [u8]) -> Result<()> {
-        (self.0.GetRNG)(
+        Result::from((self.0.GetRNG)(
             self.0,
             ptr::null(),
             buf.len(),
             buf.as_mut_ptr(),
-        )?;
+        ))?;
         Ok(())
     }
 }

--- a/src/security.rs
+++ b/src/security.rs
@@ -1,17 +1,14 @@
+use core::cell::Cell;
+use core::cmp;
+use core::ptr;
+
 use ectool::{AccessLpcDirect, Ec, SecurityState, Timeout};
 use orbclient::{Color, Renderer};
-use std::{
-    cell::Cell,
-    cmp,
-    proto::Protocol,
-    ptr,
-};
+use std::prelude::*;
+use std::proto::Protocol;
 use std::uefi::{
-    Handle,
     boot::InterfaceType,
-    guid::Guid,
     reset::ResetType,
-    status::{Error, Result, Status},
 };
 
 use crate::display::{Display, Output};
@@ -228,7 +225,7 @@ fn confirm(display: &mut Display) -> Result<()> {
                     }
                 } else {
                     // Return error if cancel selected
-                    return Err(Error::Aborted);
+                    return Err(Status::ABORTED);
                 }
             },
             Key::Escape => {
@@ -345,12 +342,12 @@ pub fn install() -> Result<()> {
     });
     let protocol_ptr = Box::into_raw(protocol);
     let mut handle = Handle(0);
-    (uefi.BootServices.InstallProtocolInterface)(
+    Result::from((uefi.BootServices.InstallProtocolInterface)(
         &mut handle,
         &SYSTEM76_SECURITY_PROTOCOL_GUID,
         InterfaceType::Native,
         protocol_ptr as usize
-    )?;
+    ))?;
 
     Ok(())
 }

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 use core::convert::TryInto;
-use core::prelude::v1::derive;
 use hwio::{Io, Pio, Mmio, ReadOnly};
 
-bitflags! {
+bitflags::bitflags! {
     /// Interrupt enable flags
     struct IntEnFlags: u8 {
         const RECEIVED = 1;
@@ -15,7 +14,7 @@ bitflags! {
     }
 }
 
-bitflags! {
+bitflags::bitflags! {
     /// Line status flags
     struct LineStsFlags: u8 {
         const INPUT_FULL = 1;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,7 +1,9 @@
+use core::ptr;
+
 use orbclient::{Color, Renderer};
 use orbfont::{Font, Text};
-use std::ptr;
-use std::uefi::status::{Error, Result};
+
+use std::prelude::*;
 
 use crate::display::Display;
 use crate::image::{self, Image};
@@ -39,7 +41,7 @@ impl Ui {
                     Ok(ok) => ok,
                     Err(err) => {
                         println!("failed to parse font: {}", err);
-                        return Err(Error::NotFound);
+                        return Err(Status::NOT_FOUND);
                     }
                 };
                 FONT = Box::into_raw(Box::new(font));
@@ -53,7 +55,7 @@ impl Ui {
                     Ok(ok) => ok,
                     Err(err) => {
                         println!("failed to parse checkbox checked: {}", err);
-                        return Err(Error::NotFound);
+                        return Err(Status::NOT_FOUND);
                     }
                 };
                 CHECKBOX_CHECKED = Box::into_raw(Box::new(image));
@@ -67,7 +69,7 @@ impl Ui {
                     Ok(ok) => ok,
                     Err(err) => {
                         println!("failed to parse checkbox unchecked: {}", err);
-                        return Err(Error::NotFound);
+                        return Err(Status::NOT_FOUND);
                     }
                 };
                 CHECKBOX_UNCHECKED = Box::into_raw(Box::new(image));


### PR DESCRIPTION
This version would allow compiling using a stable toolchain, if the use of `unaligned_references` could be removed from this project.