### PR TITLE
security: Only show prompt when unlocking

### DIFF
--- a/src/security.rs
+++ b/src/security.rs
@@ -273,12 +273,11 @@ extern "win64" fn run() -> bool {
     };
 
     debugln!("security state: {:?}", security_state);
-    if security_state == SecurityState::Lock {
-        // Already locked, so do not confirm
+
+    // Only show prompt when unlocking
+    if security_state != SecurityState::PrepareUnlock {
         return false;
     }
-
-    // Not locked, require confirmation
 
     let res = match Output::one() {
         Ok(output) => {


### PR DESCRIPTION
Do not show the unlock prompt when the system is already unlocked or preparing to lock.