### PR TITLE
Set link args in build script

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,13 +1,2 @@
 [build]
 target = "x86_64-unknown-uefi"
-
-[target.x86_64-unknown-uefi]
-rustflags = [
-    "-Clink-arg=/heap:0,0",
-    "-Clink-arg=/stack:0,0",
-    "-Clink-arg=/dll",
-    "-Clink-arg=/base:0",
-    "-Clink-arg=/align:32",
-    "-Clink-arg=/filealign:32",
-    "-Clink-arg=/subsystem:efi_boot_service_driver"
-]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+use std::env;
+
+fn main() {
+    let target = env::var("TARGET").unwrap();
+    if target.ends_with("-unknown-uefi") {
+        println!("cargo::rustc-link-arg=/heap:0,0");
+        println!("cargo::rustc-link-arg=/stack:0,0");
+        println!("cargo::rustc-link-arg=/dll");
+        println!("cargo::rustc-link-arg=/base:0");
+        println!("cargo::rustc-link-arg=/align:32");
+        println!("cargo::rustc-link-arg=/filealign:32");
+        println!("cargo::rustc-link-arg=/subsystem:efi_boot_service_driver");
+    }
+}


### PR DESCRIPTION
While working on converting our UEFI images to a workspace I found that the cargo configuration file cannot be used. `config.toml` is a *project*-level configuration. It will only be read from the current directory and up, and not in:

- package directories in a workspace
- package directory when `--manifest-path` is used

Use `build.rs` instead, which will be executed before the package is built and only apply the flags for the specific package.

Ref: https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
Ref: https://doc.rust-lang.org/cargo/reference/build-scripts.html

### Test

- Build with `--verbose` added to cargo command and verify linker scripts are still applied.
- `file target/x86_64-unknown-uefi/release/system76_firmware_setup.efi` still reports binary as EFI boot service driver.

