### PR TITLE
Use default alignment

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -9,8 +9,6 @@ fn main() {
         println!("cargo::rustc-link-arg=/stack:0,0");
         println!("cargo::rustc-link-arg=/dll");
         println!("cargo::rustc-link-arg=/base:0");
-        println!("cargo::rustc-link-arg=/align:32");
-        println!("cargo::rustc-link-arg=/filealign:32");
         println!("cargo::rustc-link-arg=/subsystem:efi_boot_service_driver");
     }
 }


### PR DESCRIPTION
Fixes the following edk2 warning:

```
Loading driver at 0x0007CAD0000 EntryPoint=0x0007CAEE700 system76_firmware_setup-a61b9ece34b9c996.efi
InstallProtocolInterface: BC62157E-3E33-4FEC-9920-2D3B36D750DF 7F62CC18
ProtectUefiImageCommon - 0x7F628AC0
  - 0x000000007CAD0000 - 0x0000000000085DA0
!!!!!!!!  Image Section Alignment(0x20) does not match Required Alignment (0x1000)  !!!!!!!!
ProtectUefiImage failed to create image properties record
```