### PR TITLE
Update toolchain, deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,15 +13,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "downcast-rs"
@@ -31,24 +31,25 @@ checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "bitflags",
  "libc",
+ "plain",
  "redox_syscall",
 ]
 
@@ -63,10 +64,11 @@ dependencies = [
 
 [[package]]
 name = "orbclient"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247ad146e19b9437f8604c21f8652423595cf710ad108af40e77d3ae6e96b827"
+checksum = "59aed3b33578edcfa1bc96a321d590d31832b6ad55a26f0313362ce687e9abd6"
 dependencies = [
+ "libc",
  "libredox",
 ]
 
@@ -91,6 +93,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "redox_hwio"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,9 +106,9 @@ checksum = "8eb516ad341a84372b5b15a5a35cf136ba901a639c8536f521b108253d7fce74"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.18"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
 dependencies = [
  "bitflags",
 ]
@@ -144,7 +152,7 @@ dependencies = [
 [[package]]
 name = "system76_ectool"
 version = "0.3.8"
-source = "git+https://github.com/system76/ec.git#206165c51dec452ff8a53bd928b21f5ce309bcf2"
+source = "git+https://github.com/system76/ec.git#ef05e145d554f4a4862258f582bbc309853ac606"
 dependencies = [
  "downcast-rs",
  "redox_hwio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-only"
 lto = true
 
 [dependencies]
-orbclient = { version = "0.3.46", default-features = false }
+orbclient = { version = "=0.3.51", default-features = false }
 orbfont = { version = "0.1.12", default-features = false, features = ["no-std"] }
 redox_uefi_std = "0.1.14"
 system76_ectool = { git = "https://github.com/system76/ec.git", default-features = false, features = ["redox_hwio"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.95.0"
 targets = ["x86_64-unknown-uefi"]
 profile = "minimal"

--- a/src/fde.rs
+++ b/src/fde.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
+#![allow(clippy::collapsible_if)]
+#![allow(clippy::collapsible_match)]
+
 use core::{char, cmp, mem, ptr, slice};
 use orbclient::{Color, Renderer};
 use orbfont::Text;
@@ -177,7 +180,7 @@ where
 pub struct ListHead<T>(ListEntry<T>);
 
 impl<T> ListHead<T> {
-    pub fn iter(&self) -> ListEntryIter<T> {
+    pub fn iter(&self) -> ListEntryIter<'_, T> {
         let next = self.0.next();
         ListEntryIter {
             start: next,

--- a/src/image/bmp.rs
+++ b/src/image/bmp.rs
@@ -35,8 +35,8 @@ pub fn parse(file_data: &[u8]) -> core::result::Result<Image, String> {
         let height = getd(0x16);
         let depth = getw(0x1C) as u32;
 
-        let bytes = (depth + 7) / 8;
-        let row_bytes = (depth * width + 31) / 32 * 4;
+        let bytes = depth.div_ceil(8);
+        let row_bytes = (depth * width).div_ceil(32) * 4;
 
         let mut blue_mask = 0xFF;
         let mut green_mask = 0xFF00;

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -79,7 +79,7 @@ impl Image {
     }
 
     /// Get a piece of the image
-    pub fn roi(&self, x: u32, y: u32, w: u32, h: u32) -> ImageRoi {
+    pub fn roi(&self, x: u32, y: u32, w: u32, h: u32) -> ImageRoi<'_> {
         let x1 = cmp::min(x, self.width());
         let y1 = cmp::min(y, self.height());
         let x2 = cmp::max(x1, cmp::min(x + w, self.width()));

--- a/src/security.rs
+++ b/src/security.rs
@@ -192,6 +192,7 @@ pub(crate) fn confirm(display: &mut Display) -> Result<()> {
             }
             Key::Character(c) => match c {
                 '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' => {
+                    #[allow(clippy::collapsible_match)]
                     if input.len() < code.len() {
                         input.push(c);
                     }
@@ -216,6 +217,7 @@ pub(crate) fn confirm(display: &mut Display) -> Result<()> {
                 input.clear();
             }
             Key::Down => {
+                #[allow(clippy::collapsible_match)]
                 if button_i + 1 < buttons.len() {
                     button_i += 1;
                 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -90,7 +90,7 @@ impl Ui {
     }
 
     //TODO: move to orbfont and optimize
-    pub fn render_text_wrapped(&self, string: &str, font_size: f32, width: u32) -> Vec<Text> {
+    pub fn render_text_wrapped(&self, string: &str, font_size: f32, width: u32) -> Vec<Text<'_>> {
         let mut texts = Vec::new();
 
         //TODO: support different whitespace differently, like newline?


### PR DESCRIPTION
Update toolchain from 1.85.0 to 1.95.0.

Address the following lints:

- `mismatched_lifetime_syntaxes`
- `clippy::collapsible_if`
- `clippy::collapsible_match`
- `clippy::manual_div_ceil`